### PR TITLE
feat: `--export-ids`オプションを追加 (fix: #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ cd create-subtitle-image
 $ pwd
 ~/work/create-subtitle-image
 $ sh ./create-subtitle-image.sh
-usage: create-subtitle-image [-h] [--font-size FONT_SIZE] [--font-family FONT_FAMILY] [--font-style FONT_STYLE] [--text-anchor {start,middle,end}] [--line-sep LINE_SEP] [--text-color TEXT_COLOR] [--letter-spacing LETTER_SPACING] [--offset-rate OFFSET_RATE]
-                             [--offset-color OFFSET_COLOR] [--offset-stroke OFFSET_STROKE] [--offset-stroke-rate OFFSET_STROKE_RATE] [--shadow-color SHADOW_COLOR] [--box-color BOX_COLOR] --srt-path SRT_PATH [--config-path CONFIG_PATH] --export-dir EXPORT_DIR
-                             [--base-dir BASE_DIR]
+usage: create-subtitle-image [-h] [--font-size FONT_SIZE] [--font-family FONT_FAMILY] [--font-style FONT_STYLE] [--text-anchor {start,middle,end}] [--line-sep LINE_SEP] [--text-color TEXT_COLOR]
+                             [--letter-spacing LETTER_SPACING] [--offset-rate OFFSET_RATE] [--offset-color OFFSET_COLOR] [--offset-stroke OFFSET_STROKE] [--offset-stroke-rate OFFSET_STROKE_RATE] [--shadow-color SHADOW_COLOR]
+                             [--box-color BOX_COLOR] [--export-ids [EXPORT_IDS ...]] --srt-path SRT_PATH [--config-path CONFIG_PATH] --export-dir EXPORT_DIR [--base-dir BASE_DIR]
 
 options:
   -h, --help            show this help message and exit
@@ -64,6 +64,8 @@ options:
                         影の色.色未指定の場合は影を表示しない. (デフォルト値: なし)
   --box-color BOX_COLOR
                         背景色.色未指定の場合は背景を塗り潰さない. (デフォルト値: なし)
+  --export-ids [EXPORT_IDS ...]
+                        出力する字幕番号. 未指定時は全ての字幕を出力する
   --srt-path SRT_PATH   字幕ファイルのパス
   --config-path CONFIG_PATH
                         設定ファイル(json形式)のパス
@@ -82,6 +84,13 @@ options:
 
 ~~~sh
 sh ./create-subtitle-image.sh --srt-path 字幕ファイルのパス --export-dir 画像出力先ディレクトリ
+~~~
+
+特定のNoの字幕のみ画像出力する場合
+
+~~~sh
+# 字幕No 2, 5のみ出力する場合
+sh ./create-subtitle-image.sh --srt-path 字幕ファイルのパス --export-dir 画像出力先ディレクトリ --export-ids 2 5
 ~~~
 
 #### 例01

--- a/create-subtitle-image.py
+++ b/create-subtitle-image.py
@@ -237,6 +237,7 @@ parser.add_argument("--shadow-color", type=str, default=None,
                     help="影の色.色未指定の場合は影を表示しない. (デフォルト値: なし)")
 parser.add_argument("--box-color", type=str, default=None,
                     help="背景色.色未指定の場合は背景を塗り潰さない. (デフォルト値: なし)")
+parser.add_argument("--export-ids", type=int, nargs='*', default=[], help="出力する字幕番号. 未指定時は全ての字幕を出力する")
 parser.add_argument("--srt-path", type=str, required=True, help="字幕ファイルのパス")
 parser.add_argument("--config-path", type=str, help="設定ファイル(json形式)のパス")
 parser.add_argument("--export-dir", type=str, required=True, help="作成した字幕画像の出力先dir.")
@@ -244,7 +245,7 @@ parser.add_argument("--base-dir", type=str, default=settings['base_dir'],
                     help=f"相対パスを絶対パスに変換する際に基準とするディレクトリ. (デフォルト値: {settings['base_dir']})")
 
 args = parser.parse_args(user_args)
-# print(args)
+print(args)
 settings.update(vars(args))
 
 if args.config_path:
@@ -289,6 +290,9 @@ if settings["shadow_color"]:
                                   settings["shadow_blur_stddeviation"], settings["shadow_dx"], settings["shadow_dy"])
 
 for item in items:
+    if len(args.export_ids) > 0 and (item['no'] not in args.export_ids):
+        continue
+
     text_group = create_text_group(item['lines'], base=[0, 0], font=settings["font_family"],
                                    font_size=(settings["font_size"] * pt), font_weight=settings["font_style"],
                                    fill=settings["text_color"], text_anchor=settings["text_anchor"], letter_spacing=settings["letter_spacing"])


### PR DESCRIPTION
指定したNoの字幕画像のみ出力可能に